### PR TITLE
Clear chat input each time after message submission

### DIFF
--- a/components/ChatWindow.tsx
+++ b/components/ChatWindow.tsx
@@ -241,6 +241,7 @@ export function ChatWindow(props: {
       } as unknown as FormEvent<HTMLFormElement>;
       
       await chat.handleSubmit(fakeEvent);
+      props.onInputChange?.(""); // Clear input after submit
       return;
     }
 


### PR DESCRIPTION
Clear chat input each time after message submission:
This PR addresses the issue where the chat input field was not being cleared after a message was sent. It adds the logic to clear the input field, improving user experience.

**Before**:

https://github.com/user-attachments/assets/c8e6dcdb-f176-471c-a949-1a754d5af72e


**After**:


https://github.com/user-attachments/assets/bc4ea7a9-2580-459a-8f70-d6343af45331

