### PR TITLE
fix: Fix portfolio balance api calling

### DIFF
--- a/app/api/chat/web3_agent/data/dataService.ts
+++ b/app/api/chat/web3_agent/data/dataService.ts
@@ -78,7 +78,7 @@ export const getPortfolioBalances = async (
           `${AGENT_CONFIG.endpoints.balances}/${address}/balances?networks=${chainId}`,
         );
         const data: AccountsAPIBalances = await response.json();
-  
+
         if (!response.ok) {
           throw new Error(await response.text() || "Failed to fetch portfolio balances");
         }

--- a/app/api/chat/web3_agent/data/dataService.ts
+++ b/app/api/chat/web3_agent/data/dataService.ts
@@ -77,13 +77,10 @@ export const getPortfolioBalances = async (
         const response = await fetch(
           `${AGENT_CONFIG.endpoints.balances}/${address}/balances?networks=${chainId}`,
         );
-        const data: ApiResponse<AccountsAPIBalances> = await response.json();
+        const data: AccountsAPIBalances = await response.json(); // Type data as AccountsAPIBalances
 
-        if (!data.success) {
-          throw new Error(data.error || "Failed to fetch portfolio balances");
-        }
 
-        return data.data!;
+        return data;
       } catch (error) {
         console.error("Error fetching portfolio balances:", error);
 

--- a/app/api/chat/web3_agent/data/dataService.ts
+++ b/app/api/chat/web3_agent/data/dataService.ts
@@ -77,9 +77,11 @@ export const getPortfolioBalances = async (
         const response = await fetch(
           `${AGENT_CONFIG.endpoints.balances}/${address}/balances?networks=${chainId}`,
         );
-        const data: AccountsAPIBalances = await response.json(); // Type data as AccountsAPIBalances
-
-
+        const data: AccountsAPIBalances = await response.json();
+  
+        if (!response.ok) {
+          throw new Error(await response.text() || "Failed to fetch portfolio balances");
+        }
         return data;
       } catch (error) {
         console.error("Error fetching portfolio balances:", error);


### PR DESCRIPTION
The original portfolio balance call check the `success` field which doesn't exist in the API response

**Before:**
![Screenshot 2025-03-21 at 15 46 54](https://github.com/user-attachments/assets/dc8121cd-10b9-42a3-83f9-781a14726f6a)

**After:**
![Screenshot 2025-03-21 at 15 46 43](https://github.com/user-attachments/assets/9384643a-76de-4b0b-aec1-e8f69e168dd0)
